### PR TITLE
Add staff tool to lookup book cover using API

### DIFF
--- a/staff/forms.py
+++ b/staff/forms.py
@@ -2,7 +2,7 @@ from django import forms
 from django.contrib.auth.models import User
 from accounts.models import Profile
 from django.utils.translation import ugettext_lazy as _
-from books.models import BookInstance2
+from books.models import BookInstance2, Book
 
 class StaffUserEditForm(forms.ModelForm):
     class Meta:

--- a/staff/urls.py
+++ b/staff/urls.py
@@ -15,3 +15,14 @@ urlpatterns = [
     path('add_copy/<int:book_id>', views.add_copy, name='add_copy'),
     path('amend_author/<int:book_id>', views.amend_author, name='amend_author'),
 ]
+
+# Two paths connected with adding a book image cover for books without a cover
+urlpatterns += [
+  path('lookup_book_cover/<int:book_id>', views.lookup_book_cover, name='lookup_book_cover'),
+  path('associate_book_cover/<int:book_id>', views.associate_book_cover, name='associate_book_cover'),
+]
+
+# This is for a future implementation of adding books
+# urlpatterns += [
+#   path('search', views.search_books, name='search_books'),
+# ]

--- a/templates/books/book.html
+++ b/templates/books/book.html
@@ -260,7 +260,10 @@
                   <p><button class="btn btn-outline-light" data-toggle="modal" data-target="#amendAuthorModal">
                     Amend author &raquo;
                   </button></p>
-                  <hr style="background-color: #f8f9fa;;"/>
+                  {% if not book.photo %}
+                    <p><a href="{% url 'lookup_book_cover' book.id %}" class="btn btn-outline-light">Lookup book cover &raquo;</a></p>
+                  {% endif %}
+                  <hr style="background-color: #f8f9fa;"/>
                 {% endif %}
                 <p><button class="btn btn-outline-light" data-toggle="modal" data-target="#addCopyModal">
                   Add copy &raquo;

--- a/templates/staff/lookup_book_cover.html
+++ b/templates/staff/lookup_book_cover.html
@@ -1,0 +1,22 @@
+{% extends 'base.html' %}
+
+{% block content %}
+
+<div class="container">
+  <div class="row">
+    <div class="col-md-8 offset-md-2">
+      <h2 class="mt-4 mb-3">Add Cover Image</h2>
+      <p>Here's a book cover image we found:</p>
+      <div style="width: min-content;" class="mb-4">
+        <img style="display: block; width: 300px" src="{{ temp_image_url }}" alt="Book Cover" />
+      </div>
+      <form action="{% url 'associate_book_cover' book.id %}" method="post">
+        {% csrf_token %}
+        <button class="btn btn-primary mr-3" type="submit">Associate Image To Book</button>
+        <a class="btn btn-secondary" href="{{ book.get_absolute_url }}">Cancel</a>
+      </form>
+    </div>
+  </div>
+</div>
+
+{% endblock %}

--- a/templates/staff/search_books.html
+++ b/templates/staff/search_books.html
@@ -1,0 +1,21 @@
+{% extends 'base.html' %}
+
+{% block content %}
+
+<h1>Search books</h1>
+
+<form action="{% url 'search_books' %}" method="GET">
+  {% csrf_token %}
+  <label for="title">Title:</label>
+  <input type="text" id="title" name="title">
+  <br>
+  <label for="author">Author:</label>
+  <input type="text" id="author" name="author">
+  <br>
+  <label for="isbn">ISBN:</label>
+  <input type="text" id="isbn" name="isbn">
+  <br>
+  <button type="submit">Search</button>
+</form>
+
+{% endblock %}


### PR DESCRIPTION
A staff tool that looks up a book image for a recently created book that has no book image associated with it. Involves interacting with the OpenLibrary API. If an image is found, the image is downloaded into a temporary folder on the server. If the image is then chosen to be associated with the book, it is, and the temporary image is removed.